### PR TITLE
build: update package to target NET 8

### DIFF
--- a/DataModel/DataModel.csproj
+++ b/DataModel/DataModel.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-      <TargetFramework>net6.0</TargetFramework>
+      <TargetFramework>net8.0</TargetFramework>
       <AssemblyName>Ichosys.DataModel</AssemblyName>
       <RootNamespace>Ichosys.DataModel</RootNamespace>
       <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
@@ -9,9 +9,9 @@
 
       <PackageId>Ichosys.DataModel</PackageId>
       <BuildNumber Condition="$(BuildNumber) == ''">0</BuildNumber>
-      <!--Comment out build number to avoid auto-updating project build properties. Uncomment for release builds only.-->
+	  <!--Comment out build number to avoid auto-updating project build properties. Uncomment for release builds only.-->
       <!--<BuildNumber>$([System.DateTime]::UtcNow.ToString(mmff))</BuildNumber>-->
-      <VersionPrefix>3.1.0</VersionPrefix>
+      <VersionPrefix>4.0.0</VersionPrefix>
       <Version>$(VersionPrefix).$(BuildNumber)</Version>
       <Description>A .NET library for building expressions dynamically.</Description>
       <Copyright>2021 hoeyi</Copyright>
@@ -83,8 +83,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ichosys.Extensions.Common" Version="1.5.0.5645" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+    <PackageReference Include="Ichosys.Extensions.Common" Version="2.0.1.2629" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Tests/DataModel.Tests.csproj
+++ b/Tests/DataModel.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
@@ -11,14 +11,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ichosys.Extensions.Common" Version="1.5.0.5645" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="Ichosys.Extensions.Common" Version="2.0.1.2629" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
### Changes ###
* Updates the target framework from .NET 6 to .NET 8

BREAKING CHANGE: remove NET 6 targeting